### PR TITLE
Fix "code:InvalidParameter.WithCaAttr" error.

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ def run_config_ssl(id, key, cer_file, key_file):
         # fullchain.cer
         "cer": tools.read_file(cer_file),
         "key": tools.read_file(key_file),
-        "type": "CA"
+        "type": "SVR"
     }
     ssl_client = ssl.get_ssl_client_instance(id, key)
     cert_list = ssl.get_cert_list(ssl_client)


### PR DESCRIPTION
修复“[TencentCloudSDKException] code:InvalidParameter.WithCaAttr message:证书CA扩展属性错误”错误。