### PR TITLE
在Docker环境中，由于目标证书文件夹中存在历史证书，新申请的证书无法覆盖，导致上传时仍使用旧证书的问题。

### DIFF
--- a/docker/update.sh
+++ b/docker/update.sh
@@ -7,7 +7,7 @@ if [ "${ACME_ENABLED:=true}" = "true" ]; then
   ${ACME_HOME}/acme.sh ${ACME_PARAMS:-} --force --issue --cert-home ${CERT_HOME} -d ${ACME_DOMAIN} -d *.${ACME_DOMAIN} --dns ${ACME_DNS_TYPE}
   # 兼容ecc证书
   if [ -d "${CERT_HOME}/${ACME_DOMAIN}_ecc" ]; then
-    cp -r ${CERT_HOME}/${ACME_DOMAIN}_ecc ${CERT_HOME}/${ACME_DOMAIN}
+    cp -rf ${CERT_HOME}/${ACME_DOMAIN}_ecc ${CERT_HOME}/${ACME_DOMAIN}
     echo "The ECC certificate is detected"
   fi
 fi


### PR DESCRIPTION
在Docker环境中，由于目标证书文件夹中存在历史证书，新申请的证书无法覆盖，导致上传时仍使用旧证书的问题。
In Docker environment, due to the existence of historical certificates in the target certificate folder, newly applied certificates can't be overwritten, resulting in the problem that old certificates are still used when uploading.