### PR TITLE
在 Docker 环境中新增更多环境变量选项，并在 README 文件中添加相应的使用说明。

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,25 +40,6 @@ docker run -d \
   ghcr.io/zfb132/qcloud-ssl-cdn:main
 ```
 
-
-不启用HTTP2
-
-```bash
-docker run -d \
-  --name qcloud-ssl-cdn \
-  --restart=unless-stopped \ 
-  -e DP_Id=xxx \
-  -e DP_Key=xxx \ 
-  -e ACME_DNS_TYPE=dns_dp \ 
-  -e ACME_DOMAIN=whuzfb.cn \
-  -e SECRETID=xxx \
-  -e SECRETKEY=xxx \
-  -e CDN_DOMAIN=www.whuzfb.cn \
-  -e RUN_NOW=true \
-  -e ENABLE_HTTP2=false \  # 不启用HTTP2
-  ghcr.io/zfb132/qcloud-ssl-cdn:main
-
-```
 #### 其他变量
 
 * `ACME_ENABLED`: 是否启用 acme，不启用将证书映射到容器`/data/certs`目录
@@ -73,7 +54,7 @@ docker run -d \
 * `DELETE_OLD_CERTS`: 是否删除适用于CDN_DOMAIN域名下的其他所有证书，默认为`true`
 * `UPDATE_SSL`: 是否进行为CDN_DOMAIN更换SSL证书的操作，默认为`true`
 * `PUSH_URLS`: 是否进行预热URL的操作，默认为`true`
-* `是否进行刷新URL的操作`: 是否进行刷新URL的操作，默认为`true`
+* `PURGE_URL`: 是否进行刷新URL的操作，默认为`true`
 
 
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,42 @@ docker run -d \
   ghcr.io/zfb132/qcloud-ssl-cdn:main
 ```
 
+
+不启用HTTP2
+
+```bash
+docker run -d \
+  --name qcloud-ssl-cdn \
+  --restart=unless-stopped \ 
+  -e DP_Id=xxx \
+  -e DP_Key=xxx \ 
+  -e ACME_DNS_TYPE=dns_dp \ 
+  -e ACME_DOMAIN=whuzfb.cn \
+  -e SECRETID=xxx \
+  -e SECRETKEY=xxx \
+  -e CDN_DOMAIN=www.whuzfb.cn \
+  -e RUN_NOW=true \
+  -e ENABLE_HTTP2=false \  # 不启用HTTP2
+  ghcr.io/zfb132/qcloud-ssl-cdn:main
+
+```
 #### 其他变量
 
 * `ACME_ENABLED`: 是否启用 acme，不启用将证书映射到容器`/data/certs`目录
 * `PUSH_URLS`: CDN 刷新/预热地址，逗号分隔
 * `PUSH_URLS_PATH`: CDN 刷新/预热地址文件路径，文件映射到 Docker 容器，**路径不能是`/data/urls.txt`**
+* `UPLOAD_SSL`: 是否上传 SSL 证书,默认为`true`
+* `ENABLE_HTTP2`: 是否启用 HTTP2，默认为`true`
+* `ENABLE_HSTS`: 是否启用 HSTS，默认为`true`
+* `HSTS_TIMEOUT_AGE`: HSTS 最大时间，默认为`31536000`
+* `HSTS_INCLUDE_SUBDOMAIN`: HSTS 包含子域，默认为`true`
+* `ENABLE_OCSP`: 是否启用 OCSP，默认为`true`
+* `DELETE_OLD_CERTS`: 是否删除适用于CDN_DOMAIN域名下的其他所有证书，默认为`true`
+* `UPDATE_SSL`: 是否进行为CDN_DOMAIN更换SSL证书的操作，默认为`true`
+* `PUSH_URLS`: 是否进行预热URL的操作，默认为`true`
+* `是否进行刷新URL的操作`: 是否进行刷新URL的操作，默认为`true`
+
+
 
 ### 使用 GitHub Action 部署
 

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -7,7 +7,7 @@ if [ "${ACME_ENABLED:=true}" = "true" ]; then
   ${ACME_HOME}/acme.sh ${ACME_PARAMS:-} --force --issue --cert-home ${CERT_HOME} -d ${ACME_DOMAIN} -d *.${ACME_DOMAIN} --dns ${ACME_DNS_TYPE}
   # 兼容ecc证书
   if [ -d "${CERT_HOME}/${ACME_DOMAIN}_ecc" ]; then
-    cp -r ${CERT_HOME}/${ACME_DOMAIN}_ecc ${CERT_HOME}/${ACME_DOMAIN}
+    cp -rf ${CERT_HOME}/${ACME_DOMAIN}_ecc ${CERT_HOME}/${ACME_DOMAIN}
     echo "The ECC certificate is detected"
   fi
 fi

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -46,30 +46,30 @@ SECRETKEY = "${SECRETKEY}"
 
 # 控制功能开关
 # 是否进行上传证书文件的操作（根据CER_FILE和KEY_FILE）
-UPLOAD_SSL = True
+UPLOAD_SSL = ${UPLOAD_SSL:-true}
 # 以下为HTTPS额外功能
 # 是否开启HTTP2
-ENABLE_HTTP2 = True
+ENABLE_HTTP2 = ${ENABLE_HTTP2:-true}
 # 是否开启HSTS
-ENABLE_HSTS = True
+ENABLE_HSTS = ${ENABLE_HSTS:-true}
 # 为HSTS设定最长过期时间（以秒为单位）
-HSTS_TIMEOUT_AGE = 31536000
+HSTS_TIMEOUT_AGE = ${HSTS_TIMEOUT_AGE:-15552000}
 # HSTS包含子域名（仅对泛域名有效）
-HSTS_INCLUDE_SUBDOMAIN = True
+HSTS_INCLUDE_SUBDOMAIN = ${HSTS_INCLUDE_SUBDOMAIN:-true}
 # 是否开启OCSP
-ENABLE_OCSP = True
+ENABLE_OCSP = ${ENABLE_OCSP:-true}
 # 是否删除适用于CDN_DOMAIN域名下的其他所有证书
 # 满足以下条件：证书适用于CDN_DOMAIN、证书id不是本次使用的id
-DELETE_OLD_CERTS = True
+DELETE_OLD_CERTS = ${DELETE_OLD_CERTS:-true}
 
 # 是否进行为CDN_DOMAIN更换SSL证书的操作
 # 若UPDATE_SSL = True且UPLOAD_SSL = True，则CERT_ID可不设置，直接利用UPLOAD_SSL的证书
-UPDATE_SSL = True
+UPDATE_SSL = ${UPDATE_SSL:-true}
 CERT_ID = ""
 # 是否进行预热URL的操作
-PUSH_URL = True
+PUSH_URL = ${PUSH_URL:-true}
 # 是否进行刷新URL的操作
-PURGE_URL = True
+PURGE_URL = ${PURGE_URL:-true}
 # 自定义的预热URL（默认会预热sitemap.xml的所有链接）文件路径
 # 该文件内，每行一个URL，例如
 # https://blog.whuzfb.cn/img/me2.jpg


### PR DESCRIPTION
控制脚本是否开启以下CDN设置可通过Docker环境变量直接进行配置：

* `UPLOAD_SSL`: 是否上传 SSL 证书,默认为`true`
* `ENABLE_HTTP2`: 是否启用 HTTP2，默认为`true`
* `ENABLE_HSTS`: 是否启用 HSTS，默认为`true`
* `HSTS_TIMEOUT_AGE`: HSTS 最大时间，默认为`31536000`
* `HSTS_INCLUDE_SUBDOMAIN`: HSTS 包含子域，默认为`true`
* `ENABLE_OCSP`: 是否启用 OCSP，默认为`true`
* `DELETE_OLD_CERTS`: 是否删除适用于CDN_DOMAIN域名下的其他所有证书，默认为`true`
* `UPDATE_SSL`: 是否进行为CDN_DOMAIN更换SSL证书的操作，默认为`true`
* `PUSH_URLS`: 是否进行预热URL的操作，默认为`true`
* `PURGE_URL`: 是否进行刷新URL的操作，默认为`true`